### PR TITLE
feat: switch to tsdb

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -136,13 +136,14 @@ loki_ingester_config:
 # @var loki_schema_config:description: Configuration block for schema_config
 loki_schema_config: |
   configs:
-    - from: 2020-10-24
-      store: boltdb-shipper
-      object_store: filesystem
-      schema: v11
+    - from: "2024-11-27"
       index:
-        prefix: index_
         period: 24h
+        prefix: index_
+      object_store: filesystem
+      schema: v13
+      store: tsdb
+
 
 # @var loki_table_manager_config:description: Configuration block for table_manager
 loki_table_manager_config: |


### PR DESCRIPTION
Starting with Loki v2.8, TSDB is the recommended Loki index. With this PR loki will use a TSDB